### PR TITLE
Remove answers to first two yes/no questions upon re-entering service…

### DIFF
--- a/test/controllers/IndexControllerSpec.scala
+++ b/test/controllers/IndexControllerSpec.scala
@@ -17,9 +17,18 @@
 package controllers
 
 import base.SpecBase
+import models.UserAnswers
+import org.mockito.ArgumentCaptor
+import org.mockito.Matchers.any
+import org.mockito.Mockito.{reset, verify, when}
+import pages.{EstateRegisteredOnlineYesNoPage, HaveUTRYesNoPage}
+import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import repositories.SessionRepository
 import uk.gov.hmrc.auth.core.AffinityGroup
+
+import scala.concurrent.Future
 
 class IndexControllerSpec extends SpecBase {
 
@@ -51,6 +60,36 @@ class IndexControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustBe routes.EstateRegisteredOnlineYesNoController.onPageLoad().url
+
+      application.stop()
+    }
+
+    "clean up answers to EstateRegisteredOnlineYesNo and HaveUtrYesNo" in {
+
+      val userAnswers = emptyUserAnswers
+        .set(EstateRegisteredOnlineYesNoPage, true).success.value
+        .set(HaveUTRYesNoPage, true).success.value
+
+      reset(sessionRepository)
+
+      val application = applicationBuilder(Some(userAnswers))
+        .overrides(bind[SessionRepository].toInstance(sessionRepository))
+        .build()
+
+      when(sessionRepository.set(any())).thenReturn(Future.successful(true))
+
+      val request = FakeRequest(GET, routes.IndexController.onPageLoad().url)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustBe routes.EstateRegisteredOnlineYesNoController.onPageLoad().url
+
+      val uaCaptor = ArgumentCaptor.forClass(classOf[UserAnswers])
+      verify(sessionRepository).set(uaCaptor.capture)
+      uaCaptor.getValue.get(EstateRegisteredOnlineYesNoPage) mustNot be(defined)
+      uaCaptor.getValue.get(HaveUTRYesNoPage) mustNot be(defined)
 
       application.stop()
     }


### PR DESCRIPTION
… i.e. if redirected from one of the estate status pages in maintain-estate-hub-frontend.