### PR TITLE
Fix declaration design

### DIFF
--- a/app/views/ConfirmationView.scala.html
+++ b/app/views/ConfirmationView.scala.html
@@ -30,13 +30,10 @@
     ) {
 
     <div class="govuk-main-wrapper--l">
-        <h1 class="form-title heading-large heading-confirmation ">
+        <h1 class="form-title heading-large heading-confirmation">
             @messages("confirmation.heading")
             <span class="reference-text">@messages("confirmation.heading2")</span>
-            <span id="estates-registration-number" class="reference-number">
-                <span aria-hidden=true>@trn</span>
-                <span class="visually-hidden">@formatReferenceNumber(trn)</span>
-            </span>
+            <span id="estates-registration-number" class="reference-number">@trn</span>
         </h1>
     </div>
 

--- a/app/views/DeclarationView.scala.html
+++ b/app/views/DeclarationView.scala.html
@@ -53,9 +53,9 @@
         )
 
         @if(affinityGroup == AffinityGroup.Agent) {
-            @components.warning("declaration.agent")
+            <p class="panel-indent">@messages("declaration.agent.warning")</p>
         } else {
-            @components.warning("declaration")
+            <p class="panel-indent">@messages("declaration.warning")</p>
         }
 
         @components.submit_button(Some("site.confirm.send"))

--- a/app/views/DeclaredAnswersView.scala.html
+++ b/app/views/DeclaredAnswersView.scala.html
@@ -30,14 +30,11 @@
 
     @components.back_link()
 
-    @components.heading("declaredAnswers.heading", headingSize = "heading-xlarge")
+    @components.heading("declaredAnswers.heading", headingSize = "heading-large")
 
     @components.button_print()
 
-    <h2>
-        <span aria-hidden=true>@messages("declaredAnswers.subheading", trn)</span>
-        <span class="visually-hidden">@messages("declaredAnswers.subheading", formatReferenceNumber(trn))</span>
-    </h2>
+    <p class="bold">@messages("declaredAnswers.trn", trn)</p>
 
     <p>@messages("declaredAnswers.p1", declarationSent)</p>
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -93,8 +93,10 @@ declaration.middleName = Your middle name (optional)
 declaration.lastName = Your last name
 declaration.paragraph1 = Please give us your email address to get a confirmation of your registration.
 declaration.paragraph2 = If you do not enter your email address, you will not receive a confirmation email with the declaration reference number.
-declaration.warning = I confirm that I have taken all reasonable steps to obtain up to date and accurate information for this registration. I understand that if I knowingly provide false information and cannot demonstrate that I have taken all reasonable steps, I could be subject to penalties.
-declaration.agent.warning = I confirm that my client has taken all reasonable steps to obtain up to date and accurate information for this registration. I understand that if my client knowingly provides false information and cannot demonstrate that they have taken all reasonable steps, they could be subject to penalties.
+
+declaration.warning = I confirm that the information I have given is true and complete to the best of my knowledge. I will make sure it is kept up to date, including any change of address. If I find out that I have made an error or something has changed, I will update the information.
+
+declaration.agent.warning = I confirm that the information my client has given is true and complete to the best of their knowledge. I will make sure it is kept up to date, including any change of address. If I find out that an error has been made or something has changed, I will update the information.
 
 declaration.error.firstName.required = Enter your first name
 declaration.error.firstName.length = Your first name must be 35 characters or less
@@ -157,7 +159,7 @@ agentOverview.start = Start now
 
 declaredAnswers.title = Declared copy of the estate’s registration
 declaredAnswers.heading = Declared copy of the estate’s registration
-declaredAnswers.subheading = Declaration reference is: {0}
+declaredAnswers.trn = Declaration reference is: {0}
 declaredAnswers.p1 = The estate’s declaration was sent on {0}
 
 draftAnswers.title = Draft copy of the estate’s registration

--- a/test/views/DeclarationViewSpec.scala
+++ b/test/views/DeclarationViewSpec.scala
@@ -59,10 +59,7 @@ class DeclarationViewSpec extends QuestionViewBehaviours[Declaration] {
       view.apply(form, AffinityGroup.Organisation)(fakeRequest, messages)
 
     val doc = asDocument(applyView(form))
-    assertContainsText(doc, "I confirm that I have taken all reasonable steps to obtain up to " +
-      "date and accurate information for this registration. I understand " +
-      "that if I knowingly provide false information and cannot demonstrate that I have taken all " +
-      "reasonable steps, I could be subject to penalties.")
+    assertContainsText(doc, "I confirm that the information I have given is true and complete to the best of my knowledge. I will make sure it is kept up to date, including any change of address. If I find out that I have made an error or something has changed, I will update the information.")
   }
 
   "render declaration warning for an Agent" in {
@@ -72,10 +69,7 @@ class DeclarationViewSpec extends QuestionViewBehaviours[Declaration] {
       view.apply(form, AffinityGroup.Agent)(fakeRequest, messages)
 
     val doc = asDocument(applyView(form))
-    assertContainsText(doc, "I confirm that my client has taken all reasonable steps to obtain up " +
-      "to date and accurate information for this registration. I understand that if my client knowingly " +"" +
-      "provides false information and cannot demonstrate that they have taken all reasonable steps, " +
-      "they could be subject to penalties.")
+    assertContainsText(doc, "I confirm that the information my client has given is true and complete to the best of their knowledge. I will make sure it is kept up to date, including any change of address. If I find out that an error has been made or something has changed, I will update the information.")
   }
 
 }


### PR DESCRIPTION
- Fixing markup of html on print out to remove h2s as it's not a heading
- Removing duplicate trn markup for visually-hidden following dac report on confirmation page
- Warning is removed and replaced with a panel-indent for declaration

![Screenshot 2020-08-06 at 14 47 33](https://user-images.githubusercontent.com/2979782/89539681-fa06dd00-d7f3-11ea-8c74-63e16884efa7.png)
![Screenshot 2020-08-06 at 14 48 43](https://user-images.githubusercontent.com/2979782/89539672-f83d1980-d7f3-11ea-8a69-60aff1102704.png)
