### PR TITLE
DDCE-6955 - ScoverageKeys Removed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import play.sbt.routes.RoutesKeys
 import sbt.Def
-import scoverage.ScoverageKeys
 
 lazy val appName: String = "register-estate-hub-frontend"
 
@@ -26,10 +25,6 @@ lazy val microservice = (project in file("."))
       "controllers.routes._"
     ),
     PlayKeys.playDefaultPort := 8822,
-    ScoverageKeys.coverageExcludedFiles := "<empty>;.*components.*;.*Routes.*",
-    ScoverageKeys.coverageMinimumStmtTotal := 80,
-    ScoverageKeys.coverageFailOnMinimum := true,
-    ScoverageKeys.coverageHighlighting := true,
     scalacOptions ++= Seq(
       "-feature",
       "-Wconf:src=routes/.*:s",

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -5,7 +5,7 @@ object CodeCoverageSettings {
 
   private val settings: Seq[Setting[?]] = Seq(
     coverageExcludedPackages := "<empty>;Reverse.*;..*Routes.*;",
-    coverageMinimumStmtTotal := 85,
+    coverageMinimumStmtTotal := 80,
     coverageFailOnMinimum := true,
     coverageHighlighting := true
   )


### PR DESCRIPTION
DDCE-6955 - ScoverageKeys removed from build.sbt file
<img width="947" height="545" alt="ScoverageKeys Removed" src="https://github.com/user-attachments/assets/b853ce7c-1ee7-4d18-b05f-3292f84355c6" />
